### PR TITLE
Auditor API SDK: SHA Pinning workflow file

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -19,7 +19,7 @@ permissions:
     - cron: 0 0 * * *
 jobs:
   generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@@0cbe94f2ca2c60bde9001577e565644e1c90d4a6
     with:
       force: ${{ github.event.inputs.force }}
       mode: pr

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -26,4 +26,8 @@ jobs:
       set_version: ${{ github.event.inputs.set_version }}
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      java_gpg_passphrase: ${{ secrets.JAVA_GPG_PASSPHRASE }}
+      java_gpg_secret_key: ${{ secrets.JAVA_GPG_SECRET_KEY }}
+      ossrh_password: ${{ secrets.OSSRH_PASSWORD }}
+      ossrh_username: ${{ secrets.OSSRH_USERNAME }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -1,0 +1,26 @@
+name: Publish
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+  statuses: write
+  id-token: write
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - .speakeasy/gen.lock
+  workflow_dispatch: {}
+jobs:
+  publish:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+    with:
+      target: vanta
+    secrets:
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      java_gpg_passphrase: ${{ secrets.JAVA_GPG_PASSPHRASE }}
+      java_gpg_secret_key: ${{ secrets.JAVA_GPG_SECRET_KEY }}
+      ossrh_password: ${{ secrets.OSSRH_PASSWORD }}
+      ossrh_username: ${{ secrets.OSSRH_USERNAME }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -14,7 +14,7 @@ permissions:
   workflow_dispatch: {}
 jobs:
   publish:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@@0cbe94f2ca2c60bde9001577e565644e1c90d4a6
     with:
       target: vanta
     secrets:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -12,6 +12,12 @@ targets:
     vanta:
         target: java
         source: Conduct an audit
+        publish:
+            java:
+                ossrhUsername: $ossrh_username
+                ossrhPassword: $ossrh_password
+                gpgSecretKey: $java_gpg_secret_key
+                gpgPassPhrase: $java_gpg_passphrase
         codeSamples:
             registry:
                 location: registry.speakeasyapi.dev/vanta/vanta/conduct-an-audit-java-code-samples


### PR DESCRIPTION
SHA pinning is a way to declare that a certain package is only accessible for a given commit in the package. 

This is to prevent attacks -- for example, a malicious actor could poison Github and push a bad commit. SHA pinning will pin up to a version that I've vetted with security. 

We have updated our allow list to enable the SHA pinned version but not the version tagged one so this PR updated that. Once this PR is merged, then I can start generating packages. 