### PR TITLE
add Vanta Gov server to overlay

### DIFF
--- a/.speakeasy/speakeasy-modifications-overlay.yaml
+++ b/.speakeasy/speakeasy-modifications-overlay.yaml
@@ -93,8 +93,6 @@ actions:
   - target: $["servers"]
     update:
       - url: https://api.vanta.com/v1
-        description: US Region API
-      - url: https://api.eu.vanta.com/v1
-        description: EU Region API
-      - url: https://api.aus.vanta.com/v1
-        description: AUS Region API
+        description: Vanta (Commercial)
+      - url: https://api.vanta-gov.com/v1
+        description: Vanta Gov (FedRAMP)


### PR DESCRIPTION
The overlay replaces the spec's servers wholesale, so without listing Gov here the SDK won't expose api.vanta-gov.com even after the spec source switches to the live Mintlify URL.

## Changes

<!-- Describe *what* you are changing in this PR. -->

## Motivation

<!-- Describe *why* you are making these changes and link to any related JIRA tickets [KK-XXXX] -->
